### PR TITLE
bug:코드에서 직접 TLS 설정

### DIFF
--- a/src/main/java/com/doogoo/doogoo/crawl/AcademicCrawler.java
+++ b/src/main/java/com/doogoo/doogoo/crawl/AcademicCrawler.java
@@ -3,6 +3,7 @@ package com.doogoo.doogoo.crawl;
 import com.doogoo.doogoo.common.error.DoogooException;
 import com.doogoo.doogoo.common.error.ErrorCode;
 import com.doogoo.doogoo.global.config.SejongPortalConfig;
+import jakarta.annotation.PostConstruct;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -10,7 +11,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
+import java.security.Security;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,9 +26,25 @@ public class AcademicCrawler {
     private static final String PORTAL_BASE = "https://portal.sejong.ac.kr";
 
     private final SejongPortalConfig config;
+    private SSLSocketFactory legacyTlsFactory;
 
     public AcademicCrawler(SejongPortalConfig config) {
         this.config = config;
+    }
+
+    @PostConstruct
+    private void initLegacyTls() {
+        // Java 17 기본 비활성화된 TLSv1, TLSv1.1을 세종대 포털 연결을 위해 허용
+        String disabled = Security.getProperty("jdk.tls.disabledAlgorithms");
+        if (disabled != null) {
+            disabled = disabled.replaceAll("\\bTLSv1\\.1\\b,?\\s*", "")
+                               .replaceAll("\\bTLSv1\\b,?\\s*", "")
+                               .replaceAll(",\\s*$", "")
+                               .trim();
+            Security.setProperty("jdk.tls.disabledAlgorithms", disabled);
+            log.info("세종대 포털 연결을 위해 레거시 TLS 활성화");
+        }
+        legacyTlsFactory = new LegacyTlsSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
     }
 
     public Document fetchCalendar(int year) {
@@ -35,6 +54,7 @@ public class AcademicCrawler {
         log.info("학사일정 페이지 요청: year={}", year);
         try {
             return Jsoup.connect(config.getCalendarUrl())
+                    .sslSocketFactory(legacyTlsFactory)
                     .userAgent(USER_AGENT)
                     .cookies(cookies)
                     .data("yy", String.valueOf(year))
@@ -54,6 +74,7 @@ public class AcademicCrawler {
             Map<String, String> cookies = new HashMap<>();
 
             Connection.Response step1 = Jsoup.connect(config.getLoginUrl())
+                    .sslSocketFactory(legacyTlsFactory)
                     .userAgent(USER_AGENT)
                     .ignoreHttpErrors(true)
                     .method(Connection.Method.GET)
@@ -61,6 +82,7 @@ public class AcademicCrawler {
             cookies.putAll(step1.cookies());
 
             Connection.Response step2 = Jsoup.connect(PORTAL_BASE + "/jsp/login/login_action.jsp")
+                    .sslSocketFactory(legacyTlsFactory)
                     .userAgent(USER_AGENT)
                     .header("Referer", config.getLoginUrl())
                     .header("Origin", PORTAL_BASE)
@@ -80,6 +102,7 @@ public class AcademicCrawler {
             }
 
             Connection.Response step3 = Jsoup.connect(PORTAL_BASE + "/comm/member/user/ssoLoginProc.do")
+                    .sslSocketFactory(legacyTlsFactory)
                     .userAgent(USER_AGENT)
                     .cookies(cookies)
                     .ignoreHttpErrors(true)

--- a/src/main/java/com/doogoo/doogoo/crawl/LegacyTlsSocketFactory.java
+++ b/src/main/java/com/doogoo/doogoo/crawl/LegacyTlsSocketFactory.java
@@ -1,0 +1,65 @@
+package com.doogoo.doogoo.crawl;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+/**
+ * TLSv1.0/1.1 등 구형 cipher를 사용하는 서버(세종대 포털)와의 연결을 위해
+ * 레거시 TLS 프로토콜을 활성화하는 SSLSocketFactory.
+ */
+public class LegacyTlsSocketFactory extends SSLSocketFactory {
+
+    private static final String[] ENABLED_PROTOCOLS = {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"};
+
+    private final SSLSocketFactory delegate;
+
+    public LegacyTlsSocketFactory(SSLSocketFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    private Socket enableLegacyTls(Socket socket) {
+        if (socket instanceof SSLSocket ssl) {
+            ssl.setEnabledProtocols(ENABLED_PROTOCOLS);
+        }
+        return socket;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return enableLegacyTls(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return enableLegacyTls(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return enableLegacyTls(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableLegacyTls(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableLegacyTls(delegate.createSocket(address, port, localAddress, localPort));
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- close #69

## 변경/구현 내용 요약

- 배포 환경 학사공지 크롤링 TLS 연결 오류 수정                                          
  
원인                                                                          
  - Java 17은 보안상 TLSv1, TLSv1.1을 jdk.tls.disabledAlgorithms에 기본 등록하여 차단                                                                         
  - 세종대 포털(portal.sejong.ac.kr)은 구형 TLS cipher를 사용 → 연결 자체 불가
                                                                                
  구현 내용                                                                     
 - LegacyTlsSocketFactory 추가                                                 
 - 소켓 생성 시 TLSv1, TLSv1.1을 포함한 프로토콜 명시적 활성화               
 - AcademicCrawler 수정                                                        
 - 서버 시작 시(@PostConstruct) jdk.tls.disabledAlgorithms에서 TLSv1/1.1 제거
 - 세종대 포털과의 모든 Jsoup 연결(로그인 3단계 + 학사일정 조회)에           
  LegacyTlsSocketFactory 적용           

## 테스트

- [x] 확인 완료
