### PR TITLE
refactor: ICS DESCRIPTION 및 제목 가공 로직 개선

### DIFF
--- a/src/main/java/com/doogoo/doogoo/calendar/application/IcsService.java
+++ b/src/main/java/com/doogoo/doogoo/calendar/application/IcsService.java
@@ -395,8 +395,8 @@ public class IcsService {
         String startStr = start.toLocalDate().format(DateTimeFormatter.BASIC_ISO_DATE);
         String endStr = end.toLocalDate().format(DateTimeFormatter.BASIC_ISO_DATE);
 
-        String desc = "신청기간:" + dateFormat(applyStart, applyEnd) + "\\n"
-                + "운영기간:" + dateFormat(operateStart, operateEnd) + "\\n"
+        String desc = "신청기간:" + dateFormat(applyStart, applyEnd) + "\n"
+                + "운영기간:" + dateFormat(operateStart, operateEnd) + "\n"
                 + (event.getDescriptionSummary() != null ? event.getDescriptionSummary() : "");
 
         sb.append("BEGIN:VEVENT\r\n");
@@ -436,7 +436,7 @@ public class IcsService {
 
         title = title.trim();
 
-        String shortened = title.replaceFirst("^(\\[.*?\\]\\s*)?\\d{4}-[12](학기)?\\s*", "").trim();
+        String shortened = title.replaceFirst("^.*?\\d{2,4}-[12](?:학기)?\\s*", "").trim();
 
         return shortened.isBlank() ? title : shortened;
     }
@@ -448,7 +448,12 @@ public class IcsService {
 
     private static String escapeIcsText(String s) {
         if (s == null) return "";
-        return s.replace("\\", "\\\\").replace(";", "\\;").replace(",", "\\,").replace("\n", "\\n");
+        return s.replace("\\", "\\\\")
+                .replace(";", "\\;")
+                .replace(",", "\\,")
+                .replace("\r\n", "\\n")
+                .replace("\n", "\\n")
+                .replace("\r", "\\n");
     }
 
     /**


### PR DESCRIPTION
## 관련 이슈

- close #110 

## 변경/구현 내용 요약

- DoDream 이벤트 제목 정규식 수정  
  - `[센터명] 제 24회 2026-1` 형태의 접두어 제거하도록 개선
- ICS DESCRIPTION 줄바꿈 처리 개선 
  - 줄바꿈을 `\n` 형식으로 escape하도록 수정

## 테스트

- [ ] 확인 완료
